### PR TITLE
Make the brain window explorable: orbit, zoom, fullscreen

### DIFF
--- a/BrainView.swift
+++ b/BrainView.swift
@@ -48,6 +48,8 @@ private let CLASS_COLORS: [SIMD4<Float>] = [
     SIMD4(0.50, 0.25, 0.40, 1),   // endocrine — pink
 ]
 
+let BRAIN_SPIN_KEY = "spin"
+
 struct BrainScene {
     let scene: SCNScene
     let cameraNode: SCNNode
@@ -123,8 +125,9 @@ func buildBrainScene(points: BrainPointsFile, sim: LIFSim) -> BrainScene {
         pool.append(node)
     }
 
-    // slow rotation about the vertical axis
-    group.runAction(.repeatForever(.rotateBy(x: 0, y: 0.35, z: 0, duration: 6)))
+    // slow rotation about the vertical axis (keyed: hover and drag take it over)
+    group.runAction(.repeatForever(.rotateBy(x: 0, y: 0.35, z: 0, duration: 6)),
+                    forKey: BRAIN_SPIN_KEY)
     group.eulerAngles = SCNVector3(-0.15, 0, 0)
 
     let camera = SCNCamera()
@@ -169,11 +172,17 @@ final class BrainRenderDriver: NSObject, SCNSceneRendererDelegate {
     }
 }
 
-// SCNView that reports clicks and hover state without needing key focus.
+// SCNView that reports clicks, drags and hover state without needing key focus.
+// A drag orbits the brain; only a press that barely moved counts as a stimulation
+// click, so aiming at a neuron and spinning the brain never fight each other.
 final class BrainSCNView: SCNView {
     var onClick: ((NSPoint) -> Void)?
+    var onDoubleClick: (() -> Void)?
     var onHover: ((Bool) -> Void)?
+    var onOrbit: ((CGFloat, CGFloat) -> Void)?
+    var onZoom: ((CGFloat) -> Void)?
     private var tracking: NSTrackingArea?
+    private var dragTravel: CGFloat = 0
 
     override func updateTrackingAreas() {
         if let t = tracking { removeTrackingArea(t) }
@@ -185,32 +194,77 @@ final class BrainSCNView: SCNView {
         super.updateTrackingAreas()
     }
     override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
-    override func mouseDown(with event: NSEvent) {
+    override func mouseDown(with event: NSEvent) { dragTravel = 0 }
+    override func mouseDragged(with event: NSEvent) {
+        dragTravel += abs(event.deltaX) + abs(event.deltaY)
+        onOrbit?(event.deltaX, event.deltaY)
+    }
+    override func mouseUp(with event: NSEvent) {
+        guard dragTravel < 3 else { return }   // it was a spin, not a stimulation
+        if event.clickCount == 2 { onDoubleClick?(); return }
+        // Stimulation fires immediately rather than waiting out the double-click
+        // interval — a delayed spike would defeat the point of watching the fly
+        // react. The first click of a double-click therefore still stimulates.
         onClick?(convert(event.locationInWindow, from: nil))
+    }
+    // Two-finger scroll zooms, on a trackpad as well as a wheel. Precise devices
+    // report deltas an order of magnitude larger than a notched wheel, so one flick
+    // would otherwise cross the whole zoom range.
+    // (Pinch-to-zoom is deliberately absent: macOS delivers magnify events only to
+    // the active app, and this panel is non-activating by design. Verified with an
+    // app-level event tap — not a single gesture event ever reaches the process.)
+    override func scrollWheel(with event: NSEvent) {
+        onZoom?(event.scrollingDeltaY * (event.hasPreciseScrollingDeltas ? 0.12 : 1))
     }
     override func mouseEntered(with event: NSEvent) { onHover?(true) }
     override func mouseExited(with event: NSEvent) { onHover?(false) }
 }
 
+// A label that is invisible to the mouse, so the controls hint never eats a
+// stimulation click in the corner it sits in.
+final class PassthroughLabel: NSTextField {
+    override func hitTest(_ point: NSPoint) -> NSView? { nil }
+}
+
+// AppKit clamps a titled window to the screen's visible frame, which left a strip
+// of desktop under the menu bar and above the Dock in fullscreen. Opting out of the
+// constraint is safe here: the panel sits below `.mainMenu`, so the menu bar (and
+// the 🪰 item needed to get back out) still draws over it.
+final class BrainPanel: NSPanel {
+    override func constrainFrameRect(_ frameRect: NSRect, to screen: NSScreen?) -> NSRect {
+        frameRect
+    }
+}
+
 final class BrainWindowController {
-    let panel: NSPanel
+    let panel: BrainPanel
     let driver: BrainRenderDriver
     private let sim: LIFSim
     private let brainGroup: SCNNode
+    private let cameraNode: SCNNode
     private let view: BrainSCNView
     private let stimRing: SCNNode
     private let label = NSTextField(labelWithString: "")
+    private var hintLines: [PassthroughLabel] = []
     private var labelHider: DispatchWorkItem?
+    /// Frame to restore when leaving fullscreen; non-nil only while fullscreen.
+    private var windowedFrame: NSRect?
+    /// Fired when a double-click flipped fullscreen, so the menu title can follow.
+    var onFullscreenChange: (() -> Void)?
+
+    static let windowedMask: NSWindow.StyleMask =
+        [.titled, .closable, .resizable, .utilityWindow, .nonactivatingPanel]
+    static let panelTitle = "Fly Brain — FlyWire v783 (click = stimulate)"
 
     init(points: BrainPointsFile, sim: LIFSim, screen: NSScreen) {
         self.sim = sim
         let size = NSSize(width: 340, height: 280)
         let vis = screen.visibleFrame
         let origin = NSPoint(x: vis.maxX - size.width - 18, y: vis.minY + 18)
-        panel = NSPanel(contentRect: NSRect(origin: origin, size: size),
-                        styleMask: [.titled, .closable, .utilityWindow, .nonactivatingPanel],
-                        backing: .buffered, defer: false)
-        panel.title = "Fly Brain — FlyWire v783 (click = stimulate)"
+        panel = BrainPanel(contentRect: NSRect(origin: origin, size: size),
+                           styleMask: BrainWindowController.windowedMask,
+                           backing: .buffered, defer: false)
+        panel.title = BrainWindowController.panelTitle
         panel.level = .floating
         panel.isFloatingPanel = true
         panel.becomesKeyOnlyIfNeeded = true
@@ -220,6 +274,7 @@ final class BrainWindowController {
 
         let bs = buildBrainScene(points: points, sim: sim)
         brainGroup = bs.brainGroup
+        cameraNode = bs.cameraNode
         driver = BrainRenderDriver(sim: sim, flashPool: bs.flashPool)
 
         // reusable stimulation ring
@@ -255,10 +310,65 @@ final class BrainWindowController {
         label.isHidden = true
         view.addSubview(label)
 
+        // Controls hint, pinned to the top-left corner. Two single-line labels rather
+        // than one multi-line one: `labelWithString:` builds a single-line-mode field,
+        // where an embedded newline silently renders nothing. Struts hold them in the
+        // corner when the panel is resized or goes fullscreen.
+        for line in ["Drag to rotate · Scroll to zoom",
+                     "Click to stimulate · Double-click for fullscreen"] {
+            let l = PassthroughLabel(labelWithString: line)
+            l.font = NSFont.systemFont(ofSize: 10, weight: .medium)
+            l.textColor = NSColor(calibratedWhite: 0.62, alpha: 1)
+            l.sizeToFit()
+            l.autoresizingMask = [.maxXMargin, .minYMargin]
+            view.addSubview(l)
+            hintLines.append(l)
+        }
+        layoutHint(topInset: 0)
+
+        // Hold the ambient rotation while aiming, resume it when the cursor leaves.
+        // Stopping the action (rather than pausing the node) keeps spike flashes
+        // alive while you hover, and leaves the orientation free for dragging.
         view.onHover = { [weak self] hovering in
-            self?.brainGroup.isPaused = hovering   // hold the rotation while aiming
+            hovering ? self?.stopSpin() : self?.startSpin()
         }
         view.onClick = { [weak self] p in self?.handleClick(at: p) }
+        view.onOrbit = { [weak self] dx, dy in self?.orbit(dx: dx, dy: dy) }
+        view.onZoom = { [weak self] d in self?.zoom(by: d) }
+        view.onDoubleClick = { [weak self] in
+            self?.toggleFullscreen()
+            self?.onFullscreenChange?()
+        }
+    }
+
+    private func stopSpin() {
+        guard brainGroup.action(forKey: BRAIN_SPIN_KEY) != nil else { return }
+        brainGroup.removeAction(forKey: BRAIN_SPIN_KEY)
+        brainGroup.eulerAngles = brainGroup.presentation.eulerAngles   // no snap-back
+    }
+
+    private func startSpin() {
+        guard brainGroup.action(forKey: BRAIN_SPIN_KEY) == nil else { return }
+        brainGroup.runAction(.repeatForever(.rotateBy(x: 0, y: 0.35, z: 0, duration: 6)),
+                             forKey: BRAIN_SPIN_KEY)
+    }
+
+    /// Drag to orbit. Pitch is clamped short of the poles so the brain never flips
+    /// upside down — anatomical up stays up, which is how connectome viewers show it.
+    private func orbit(dx: CGFloat, dy: CGFloat) {
+        stopSpin()
+        var e = brainGroup.eulerAngles
+        e.y += dx * 0.01
+        e.x = min(max(e.x + dy * 0.01, -1.3), 1.3)
+        brainGroup.eulerAngles = e
+    }
+
+    /// Scroll to dolly the camera. Bounds keep the brain inside the near/far planes
+    /// (zNear 1, zFar 120) — past them it would clip through or vanish.
+    private func zoom(by delta: CGFloat) {
+        var p = cameraNode.position
+        p.z = min(max(p.z - delta * 0.35, 9), 70)
+        cameraNode.position = p
     }
 
     private func handleClick(at p: NSPoint) {
@@ -347,7 +457,73 @@ final class BrainWindowController {
     func show() { panel.orderFront(nil) }
     func hide() { panel.orderOut(nil) }
 
+    var isFullscreen: Bool { windowedFrame != nil }
+
+    var isHintVisible: Bool { !(hintLines.first?.isHidden ?? true) }
+
+    func toggleHint() {
+        let hide = isHintVisible
+        for l in hintLines { l.isHidden = hide }
+    }
+
+    /// Places the controls hint in the top-left of the content view. In fullscreen the
+    /// panel reaches under the menu bar, which draws above it — without the inset the
+    /// hint sits behind the menu bar and is invisible.
+    private func layoutHint(topInset: CGFloat) {
+        var y = view.bounds.height - 8 - topInset
+        for l in hintLines {
+            y -= l.frame.height
+            l.setFrameOrigin(NSPoint(x: 10, y: y))
+        }
+    }
+
+    private func setTitlebarButtons(hidden: Bool) {
+        for b in [NSWindow.ButtonType.closeButton, .miniaturizeButton, .zoomButton] {
+            panel.standardWindowButton(b)?.isHidden = hidden
+        }
+    }
+
+    /// Chromeless full-screen brain. Not a native fullscreen Space on purpose: the
+    /// panel is non-activating and joins all Spaces, and the fly overlay has to keep
+    /// living on the desktop in front of it. The panel stays below the menu bar, so
+    /// the 🪰 menu remains reachable to toggle back out.
+    func toggleFullscreen() {
+        if let f = windowedFrame {
+            windowedFrame = nil
+            panel.styleMask.remove(.fullSizeContentView)
+            panel.titlebarAppearsTransparent = false
+            panel.titleVisibility = .visible
+            setTitlebarButtons(hidden: false)
+            panel.isMovableByWindowBackground = true
+            panel.level = .floating
+            panel.setFrame(f, display: true)
+            layoutHint(topInset: 0)
+        } else {
+            windowedFrame = panel.frame
+            let screen = panel.screen ?? NSScreen.main ?? NSScreen.screens[0]
+            // Hide the chrome by making the content view span the full frame rather
+            // than by dropping `.titled`: an NSPanel keeps its titlebar when the style
+            // mask loses `.titled` at runtime (verified — the bar stayed on screen).
+            panel.styleMask.insert(.fullSizeContentView)
+            panel.titlebarAppearsTransparent = true
+            panel.titleVisibility = .hidden
+            setTitlebarButtons(hidden: true)
+            panel.isMovableByWindowBackground = false   // whole surface is click-to-stimulate
+            // One notch below the fly overlay (also .floating), so the fly walks
+            // across the brain instead of behind it. The overlay ignores mouse
+            // events, so clicks still land here and stimulate neurons.
+            panel.level = NSWindow.Level(rawValue: NSWindow.Level.floating.rawValue - 1)
+            panel.setFrame(screen.frame, display: true)
+            layoutHint(topInset: screen.frame.maxY - screen.visibleFrame.maxY)
+        }
+        panel.orderFront(nil)
+    }
+
     func move(to screen: NSScreen) {
+        if isFullscreen {
+            panel.setFrame(screen.frame, display: true)
+            return
+        }
         let size = panel.frame.size
         let vis = screen.visibleFrame
         panel.setFrameOrigin(NSPoint(x: vis.maxX - size.width - 18, y: vis.minY + 18))

--- a/main.swift
+++ b/main.swift
@@ -710,6 +710,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     var dataInfo = "no data — run etl.py"
     var screenFrame = NSRect.zero
     var moveDisplayItem: NSMenuItem?
+    var brainFullscreenItem: NSMenuItem?
+    var brainHintItem: NSMenuItem?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         guard let screen = NSScreen.main else { fatalError("no screen") }
@@ -752,6 +754,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
 
         if let sim = sim, let pts = brainPoints {
             let wc = BrainWindowController(points: pts, sim: sim, screen: screen)
+            wc.onFullscreenChange = { [weak self] in self?.syncFullscreenItem() }
             wc.show()
             brainWC = wc
         }
@@ -840,6 +843,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         }
         menu.addItem(item("Pause", #selector(togglePause(_:)), "p"))
         menu.addItem(item("Show/Hide Brain", #selector(toggleBrain), "b"))
+        let full = item("Fullscreen Brain", #selector(toggleBrainFullscreen), "f")
+        menu.addItem(full)
+        brainFullscreenItem = full
+        let hint = item("Hide Brain Hint", #selector(toggleBrainHint), "h")
+        menu.addItem(hint)
+        brainHintItem = hint
         menu.addItem(item("Escape Test (loom)", #selector(escapeTest), "e"))
         let move = item("Move to Next Display", #selector(moveToNextDisplay), "d")
         menu.addItem(move)
@@ -862,6 +871,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     @objc func toggleBrain() {
         guard let wc = brainWC else { return }
         wc.isVisible ? wc.hide() : wc.show()
+    }
+    @objc func toggleBrainFullscreen() {
+        guard let wc = brainWC else { return }
+        wc.toggleFullscreen()
+        syncFullscreenItem()
+    }
+    @objc func toggleBrainHint() {
+        guard let wc = brainWC else { return }
+        wc.toggleHint()
+        brainHintItem?.title = wc.isHintVisible ? "Hide Brain Hint" : "Show Brain Hint"
+    }
+    func syncFullscreenItem() {
+        guard let wc = brainWC else { return }
+        brainFullscreenItem?.title = wc.isFullscreen ? "Exit Fullscreen Brain" : "Fullscreen Brain"
     }
     @objc func escapeTest() { coordinator.escapeTest() }
     @objc func addFly() { coordinator.addFly() }


### PR DESCRIPTION
The brain window draws 23,210 real soma positions in anatomical space, which is
the most interesting thing on screen — but you can only ever see it from one
angle. It auto-rotates about the vertical axis, and the only input is a click
that stimulates. This PR makes the window directly manipulable and adds a
fullscreen mode. Nothing in the simulation, the circuit or the fly's behaviour
is touched.

### Interaction

- **Drag to orbit.** Pitch is clamped short of the poles so anatomical up stays
  up, the way connectome viewers present it.
- **Scroll to zoom.** The camera dollies between bounds that keep the brain
  inside the scene's near/far planes. Precise scrolling devices are scaled down
  — their deltas are an order of magnitude larger than a notched wheel, and one
  trackpad flick would otherwise cross the entire range.
- **Click still stimulates.** Orbiting and aiming are told apart by how far the
  pointer travelled between press and release (< 3 pt is a click), so the two
  gestures never steal each other.
- **Double-click toggles fullscreen**, as does a new `Fullscreen Brain` menu
  item (`Cmd-F`), whose title tracks the current state.
- **The panel is resizable.** It was previously pinned at 340×280.
- **A two-line controls hint** sits in the top-left. It is transparent to the
  mouse, so it never swallows a stimulation click in the corner it occupies, and
  it can be dismissed from the menu (`Cmd-H`) once the controls are familiar.

### Bug fix included

`onHover` set `brainGroup.isPaused = true` to hold the rotation while aiming.
The spike flash pool are children of that same node, so hovering also froze the
flashes — the activity you were hovering to aim at visibly stopped. The ambient
rotation is now a keyed action that is removed on hover/drag and restored on
exit, which holds the orientation without pausing anything else.

### Fullscreen design notes

Every one of these is deliberate; happy to change any of them if you'd rather.

- **Not a native fullscreen Space.** The panel is `.nonactivatingPanel` and
  `.canJoinAllSpaces`, and the fly overlay has to keep living on the desktop in
  front of it. A native Space breaks both.
- **The panel drops one level below the fly overlay while fullscreen**, so the
  fly walks *across* the brain instead of disappearing behind it. The overlay
  sets `ignoresMouseEvents`, so clicks still reach the brain and stimulate.
- **It stays below the menu bar**, which keeps the 🪰 menu reachable to get back
  out — otherwise fullscreen would be a trap on a machine with no keyboard
  shortcut muscle memory. The controls hint is inset by the menu bar height for
  the same reason.
- **Chrome is hidden via `fullSizeContentView` + hidden titlebar**, not by
  dropping `.titled` from the style mask: an `NSPanel` keeps its titlebar when
  `.titled` is removed at runtime.
- **`constrainFrameRect` is overridden** because AppKit otherwise clamps a
  titled window to the screen's *visible* frame, which left strips of desktop
  under the menu bar and above the Dock.

### Not included

**Pinch-to-zoom.** I tried and it cannot work as things stand. macOS delivers
`magnify` events only to the active application, and this panel is
non-activating by design. Verified with an application-level event monitor: zero
gesture events reach the process, against 169 scroll events in the same session,
and adding an `NSMagnificationGestureRecognizer` changed nothing. Activating the
app on click made it work at the cost of stealing focus from whatever you were
typing in, which seemed a bad trade for a desktop pet. Two-finger scroll zooms
on a trackpad regardless, so the gesture is covered, just not that gesture.

### Testing

macOS 26.6, Apple silicon, built with `./build.sh`. Exercised windowed →
fullscreen → windowed repeatedly and verified the panel geometry and the hint
placement from screenshots in both states; checked that stimulation, the region
labels, the ambient rotation and the spike flashes all still behave. No new
compiler warnings.

Happy to split this into separate commits (orbit/zoom, fullscreen, hint) if you
prefer smaller reviews.
