### PR TITLE
perf: cut CPU roughly in half (profile-driven, no model change)

### DIFF
--- a/BrainView.swift
+++ b/BrainView.swift
@@ -147,28 +147,72 @@ final class BrainRenderDriver: NSObject, SCNSceneRendererDelegate {
     let sim: LIFSim
     let flashPool: [SCNNode]
     private var next = 0
+    // Fade state per pool slot, stepped by hand. The pool holds a few dozen
+    // nodes while a single frame drains hundreds of sampled spikes, so the old
+    // one-SCNAction-per-spike path built and immediately cancelled thousands of
+    // action sequences a second — it was the brain window's largest cost.
+    private var fadeLeft: [Double]
+    private var fadeSpan: [Double]
+    private var fadeFrom: [Double]
+    private var lastTime: TimeInterval = 0
 
     init(sim: LIFSim, flashPool: [SCNNode]) {
         self.sim = sim
         self.flashPool = flashPool
+        fadeLeft = [Double](repeating: 0, count: flashPool.count)
+        fadeSpan = [Double](repeating: 1, count: flashPool.count)
+        fadeFrom = [Double](repeating: 0, count: flashPool.count)
     }
 
     func flash(neuron: Int, isGF: Bool) {
-        guard neuron < sim.n, !flashPool.isEmpty else { return }
-        let node = flashPool[next]
+        guard !flashPool.isEmpty else { return }
+        let slot = next
         next = (next + 1) % flashPool.count
+        light(slot: slot, neuron: neuron, isGF: isGF)
+    }
+
+    private func light(slot: Int, neuron: Int, isGF: Bool) {
+        guard neuron < sim.n else { return }
+        let node = flashPool[slot]
         let p = sim.positions[neuron]
         node.position = SCNVector3(CGFloat(p.x), CGFloat(p.y), CGFloat(p.z))
         node.isHidden = false
-        node.removeAllActions()
         node.opacity = isGF ? 1.0 : 0.8
         node.scale = isGF ? SCNVector3(3.2, 3.2, 3.2) : SCNVector3(1, 1, 1)
-        node.runAction(.sequence([.fadeOut(duration: isGF ? 0.6 : 0.28), .hide()]))
+        fadeFrom[slot] = isGF ? 1.0 : 0.8
+        fadeSpan[slot] = isGF ? 0.6 : 0.28      // same durations as the old fadeOut
+        fadeLeft[slot] = fadeSpan[slot]
     }
 
     func renderer(_ renderer: SCNSceneRenderer, updateAtTime time: TimeInterval) {
+        let dt = lastTime == 0 ? 0 : max(0, min(0.25, time - lastTime))
+        lastTime = time
+
+        for slot in flashPool.indices where fadeLeft[slot] > 0 {
+            fadeLeft[slot] -= dt
+            if fadeLeft[slot] <= 0 {
+                fadeLeft[slot] = 0
+                flashPool[slot].isHidden = true          // the old .hide() tail
+            } else {
+                flashPool[slot].opacity = CGFloat(fadeFrom[slot] * fadeLeft[slot] / fadeSpan[slot])
+            }
+        }
+
         guard let bus = sim.spikeBus else { return }
-        for e in bus.popAll() { flash(neuron: e.neuron, isGF: e.isGF) }
+        let events = bus.popAll()
+        guard !events.isEmpty else { return }
+        // Resolve the round-robin before touching SceneKit: every slot but the
+        // last one written per frame is overwritten before it is ever drawn, so
+        // replaying the assignments into a local buffer gives the identical
+        // final state with one node update per slot instead of one per spike.
+        var latest = [(neuron: Int, isGF: Bool)?](repeating: nil, count: flashPool.count)
+        for e in events {
+            latest[next] = e
+            next = (next + 1) % flashPool.count
+        }
+        for (slot, e) in latest.enumerated() {
+            if let e { light(slot: slot, neuron: e.neuron, isGF: e.isGF) }
+        }
     }
 }
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,12 @@ models. Do not claim biologically calibrated walking from anatomical checks.
 
 ```sh
 ./build.sh                     # bare swiftc, -swift-version 5, no Xcode project
+                               # -O -wmo -enforce-exclusivity=unchecked; see build.sh
+                               # for why the exclusivity check is off (it was the
+                               # single largest cost in the profile)
 ./DesktopFly                   # menu-bar 🪰; quit from there
+                               # DESKTOPFLY_QUALITY=high -> 120 fps / 4x MSAA overlay
+                               # (default 60 / 2x; neither changes the model)
 ./DesktopFly --simtest         # circuit invariants (MUST pass after sim/etl changes)
 ./DesktopFly --behaviortest    # end-to-end sim→body checks (MUST pass after behavior changes)
 ./DesktopFly --locomotortest   # active MaleCNS/body loop (MUST pass after shared motor changes)

--- a/Locomotor.swift
+++ b/Locomotor.swift
@@ -44,6 +44,18 @@ struct LocomotorParameters {
 }
 
 final class LocomotorSim {
+    // The per-millisecond loops below run over ~1,000 neurons a thousand times a
+    // second, so everything they touch is resolved to an integer index here at
+    // init: a string compare, a dictionary hash, or a copy of a neuron struct
+    // (six retained String fields) inside those loops costs more than the LIF
+    // arithmetic it guards. Names still come from the data; only lookups change.
+    static let motorChannelNames = [
+        "coxa_promotor", "coxa_anterior_rotator", "coxa_remotor", "coxa_posterior_rotator",
+        "trochanter_flexor", "trochanter_extensor", "tibia_flexor", "tibia_extensor",
+    ]
+    private enum Role: UInt8 { case other = 0, motor, sensory, descending, ascending }
+    private enum SensoryKind: UInt8 { case load = 0, hairPlate, excursion }
+
     let circuit: LocomotorCircuitFile
     let n: Int
     private var voltage: [Double]
@@ -59,9 +71,13 @@ final class LocomotorSim {
     private var weights: [Double]
     private var drive: [Double]
     private var sensoryDrive: [Double]
-    private var commandGroups: [String: [Int]] = [:]
-    private var motorGroups = Array(repeating: [String: [Int]](), count: 6)
+    private var roleCode: [UInt8] = []
+    private var commandGroupIds: [[Int]] = []
+    private var commandGroupIndex: [String: Int] = [:]
+    private var motorChannelIds: [[Int]] = []   // leg * motorChannelNames.count + channel
     private var sensory: [Int] = []
+    private var sensoryLeg: [Int] = []          // parallel to `sensory`
+    private var sensoryKind: [UInt8] = []       // parallel to `sensory`
     private(set) var commands = Array(repeating: LegMotorCommand(), count: 6)
     private(set) var totalSpikes = 0
     private(set) var motorSpikes = 0
@@ -69,7 +85,16 @@ final class LocomotorSim {
     private(set) var simMs = 0
     var feedback: [LegFeedback] = []
     // Lesions are diagnostic interventions, used to verify actual causal paths.
-    var silenced: Set<Int> = []
+    // The set stays the API; the hot loop reads the mirrored flags instead, so a
+    // normal run costs one Bool check rather than a hash per neuron per ms.
+    var silenced: Set<Int> = [] {
+        didSet {
+            anySilenced = !silenced.isEmpty
+            for i in 0..<n { silencedFlag[i] = silenced.contains(i) }
+        }
+    }
+    private var silencedFlag: [Bool] = []
+    private var anySilenced = false
     var synapsesEnabled = true
     var feedbackEnabled = true
     let parameters: LocomotorParameters
@@ -89,6 +114,17 @@ final class LocomotorSim {
         nextInhibitory = .init(repeating: 0, count: n)
         drive = .init(repeating: 0, count: n)
         sensoryDrive = .init(repeating: 0, count: n)
+        silencedFlag = .init(repeating: false, count: n)
+        roleCode = circuit.neurons.map {
+            switch $0.role {
+            case "motor": return Role.motor.rawValue
+            case "sensory": return Role.sensory.rawValue
+            case "descending": return Role.descending.rawValue
+            case "ascending": return Role.ascending.rawValue
+            default: return Role.other.rawValue
+            }
+        }
+        motorChannelIds = Array(repeating: [], count: 6 * Self.motorChannelNames.count)
         var counts = Array(repeating: 0, count: n)
         var inputTotal = Array(repeating: Double(0), count: n)
         for e in circuit.edges {
@@ -110,11 +146,30 @@ final class LocomotorSim {
         }
         for (i, nr) in circuit.neurons.enumerated() {
             if nr.role == "descending" {
-                commandGroups["\(nr.type):\(nr.side)", default: []].append(i)
+                let key = "\(nr.type):\(nr.side)"
+                let group: Int
+                if let existing = commandGroupIndex[key] { group = existing }
+                else {
+                    group = commandGroupIds.count
+                    commandGroupIndex[key] = group
+                    commandGroupIds.append([])
+                }
+                commandGroupIds[group].append(i)
             }
-            if nr.role == "sensory", nr.leg != nil { sensory.append(i) }
-            if nr.role == "motor", let leg = nr.leg, let channel = nr.motorChannel {
-                motorGroups[leg][channel, default: []].append(i)
+            if nr.role == "sensory", let leg = nr.leg {
+                sensory.append(i)
+                sensoryLeg.append(leg)
+                // Same three-way split the step loop used to spell out with
+                // string compares; the pooling rationale is unchanged.
+                let kind: SensoryKind
+                if nr.sensoryKind == "campaniform" || nr.sensoryKind == "contact" { kind = .load }
+                else if nr.sensoryKind == "hair_plate" { kind = .hairPlate }
+                else { kind = .excursion }
+                sensoryKind.append(kind.rawValue)
+            }
+            if nr.role == "motor", let leg = nr.leg, let channel = nr.motorChannel,
+               let slot = Self.motorChannelNames.firstIndex(of: channel) {
+                motorChannelIds[leg * Self.motorChannelNames.count + slot].append(i)
             }
         }
     }
@@ -122,21 +177,40 @@ final class LocomotorSim {
     // A modeled homologous population-rate interface between female FlyWire
     // and male CNS specimens. It adds current, never fabricated graph edges.
     func setDescending(_ type: String, side: String, rate: Float) {
-        for i in commandGroups["\(type):\(side)"] ?? [] {
-            drive[i] = min(0.35, max(0, Double(rate)) * 0.004)
-        }
+        guard let group = commandGroupIndex["\(type):\(side)"] else { return }
+        setDescending(group: group, rate: rate)
+    }
+
+    // Index form of the above, for the caller that resolves its groups once.
+    func descendingGroup(_ type: String, side: String) -> Int? {
+        commandGroupIndex["\(type):\(side)"]
+    }
+
+    func setDescending(group: Int, rate: Float) {
+        let value = min(0.35, max(0, Double(rate)) * 0.004)
+        for i in commandGroupIds[group] { drive[i] = value }
     }
 
     func meanRate(role: String, leg: Int? = nil) -> Float {
-        let ids = circuit.neurons.indices.filter {
-            circuit.neurons[$0].role == role && (leg == nil || circuit.neurons[$0].leg == leg)
-        }
+        let ids = indices(role: role, leg: leg)
         return Float(ids.reduce(0) { $0 + rates[$1] } / Double(max(1, ids.count)))
     }
 
     func indices(role: String, leg: Int? = nil) -> [Int] {
-        circuit.neurons.indices.filter {
-            circuit.neurons[$0].role == role && (leg == nil || circuit.neurons[$0].leg == leg)
+        guard let code = Self.roleCode(role) else { return [] }
+        return (0..<n).filter {
+            roleCode[$0] == code && (leg == nil || circuit.neurons[$0].leg == leg)
+        }
+    }
+
+    private static func roleCode(_ role: String) -> UInt8? {
+        switch role {
+        case "motor": return Role.motor.rawValue
+        case "sensory": return Role.sensory.rawValue
+        case "descending": return Role.descending.rawValue
+        case "ascending": return Role.ascending.rawValue
+        case "premotor": return Role.other.rawValue
+        default: return nil
         }
     }
 
@@ -147,21 +221,22 @@ final class LocomotorSim {
             // Leg-local sensory transduction, without global gait phase or
             // neuron-ID-derived tuning. Missing direction tuning is pooled:
             // proprioceptors encode joint excursion/speed; contact sensors load.
-            for i in sensory { sensoryDrive[i] = 0 }
+            for k in sensory.indices { sensoryDrive[sensory[k]] = 0 }
             if feedbackEnabled && feedback.count == 6 {
-                for i in sensory {
-                    let nr = circuit.neurons[i], f = feedback[nr.leg!]
+                for k in sensory.indices {
+                    let f = feedback[sensoryLeg[k]]
                     let value: CGFloat
-                    if nr.sensoryKind == "campaniform" || nr.sensoryKind == "contact" {
+                    switch sensoryKind[k] {
+                    case SensoryKind.load.rawValue:
                         value = f.contact ? min(1, f.load * 6) : 0
-                    } else if nr.sensoryKind == "hair_plate" {
+                    case SensoryKind.hairPlate.rawValue:
                         value = min(1, abs(f.hipAngle) / LegDynamics.hipLimit
                                     + abs(f.elevationVelocity) / 20)
-                    } else {
+                    default:
                         value = min(1, abs(f.kneeVelocity) / 20 + abs(f.hipVelocity) / 16
                                       + abs(f.kneeAngle - LegDynamics.restKnee) * 0.35)
                     }
-                    sensoryDrive[i] = Double(value) * 0.10
+                    sensoryDrive[sensory[k]] = Double(value) * 0.10
                 }
             }
             for i in 0..<n {
@@ -175,7 +250,7 @@ final class LocomotorSim {
             for i in 0..<n {
                 rates[i] *= 0.9048374 // 10 ms rate time constant for fast muscles
                 adaptation[i] *= 0.9950125 // 200 ms spike-frequency adaptation
-                if silenced.contains(i) {
+                if anySilenced && silencedFlag[i] {
                     voltage[i] = 0; rates[i] = 0; continue
                 }
                 if refractory[i] > 0 { refractory[i] -= 1; continue }
@@ -188,8 +263,8 @@ final class LocomotorSim {
                     adaptation[i] += parameters.adaptationKick
                     rates[i] += 95.16258
                     totalSpikes += 1
-                    if circuit.neurons[i].role == "motor" { motorSpikes += 1 }
-                    if circuit.neurons[i].role == "sensory" { sensorySpikes += 1 }
+                    if roleCode[i] == Role.motor.rawValue { motorSpikes += 1 }
+                    else if roleCode[i] == Role.sensory.rawValue { sensorySpikes += 1 }
                     if synapsesEnabled {
                         for e in rowStart[i]..<rowStart[i + 1] {
                             if weights[e] >= 0 { nextExcitatory[targets[e]] += weights[e] }
@@ -200,16 +275,20 @@ final class LocomotorSim {
             }
         }
         for leg in 0..<6 {
-            func activity(_ channel: String) -> CGFloat {
-                let ids = motorGroups[leg][channel] ?? []
-                let rate = ids.reduce(0) { $0 + rates[$1] } / Double(max(1, ids.count))
+            let base = leg * Self.motorChannelNames.count
+            func activity(_ slot: Int) -> CGFloat {
+                let ids = motorChannelIds[base + slot]
+                guard !ids.isEmpty else { return 0 }
+                let rate = ids.reduce(0) { $0 + rates[$1] } / Double(ids.count)
                 return CGFloat(rate / (rate + 50))
             }
+            // Slots follow motorChannelNames: promotor, anterior rotator, remotor,
+            // posterior rotator, trochanter flexor/extensor, tibia flexor/extensor.
             commands[leg] = LegMotorCommand(
-                protract: max(activity("coxa_promotor"), activity("coxa_anterior_rotator")),
-                retract: max(activity("coxa_remotor"), activity("coxa_posterior_rotator")),
-                lift: activity("trochanter_flexor"), depress: activity("trochanter_extensor"),
-                flex: activity("tibia_flexor"), extend: activity("tibia_extensor"))
+                protract: max(activity(0), activity(1)),
+                retract: max(activity(2), activity(3)),
+                lift: activity(4), depress: activity(5),
+                flex: activity(6), extend: activity(7))
         }
     }
 }

--- a/Sim.swift
+++ b/Sim.swift
@@ -5,6 +5,26 @@
 import Foundation
 import simd
 
+// Membrane noise needs one draw per neuron per simulated millisecond — ~670,000
+// a second. SystemRandomNumberGenerator is an AES-CTR CSPRNG, and its ccrng/
+// ccaes frames were a measurable slice of the profile for what is a jitter term.
+// Seed from the system generator, then run splitmix64: still uncorrelated, at a
+// few instructions per draw. Seeded test runs never reach this (see TestRandom).
+struct FastRandom: RandomNumberGenerator {
+    private var state: UInt64
+    init() {
+        var system = SystemRandomNumberGenerator()
+        state = system.next()
+    }
+    mutating func next() -> UInt64 {
+        state &+= 0x9E37_79B9_7F4A_7C15
+        var z = state
+        z = (z ^ (z >> 30)) &* 0xBF58_476D_1CE4_E5B9
+        z = (z ^ (z >> 27)) &* 0x94D0_49BB_1331_11EB
+        return z ^ (z >> 31)
+    }
+}
+
 // Opt-in, repeatable test stimuli. Without reset(), every call below delegates
 // to the same platform RNG used by the application before test seeding existed.
 // The test stream matches windows/test/random.js: FNV-1a(label), then LCG32.
@@ -31,7 +51,7 @@ enum TestRandom {
         return range.lowerBound + (range.upperBound - range.lowerBound) * Float(u)
     }
 
-    static func float(in range: ClosedRange<Float>, using rng: inout SystemRandomNumberGenerator) -> Float {
+    static func float(in range: ClosedRange<Float>, using rng: inout some RandomNumberGenerator) -> Float {
         guard let u = unit() else { return Float.random(in: range, using: &rng) }
         return range.lowerBound + (range.upperBound - range.lowerBound) * Float(u)
     }
@@ -46,7 +66,7 @@ enum TestRandom {
         return range.lowerBound + min(range.count - 1, Int(u * Double(range.count)))
     }
 
-    static func integer(in range: ClosedRange<Int>, using rng: inout SystemRandomNumberGenerator) -> Int {
+    static func integer(in range: ClosedRange<Int>, using rng: inout some RandomNumberGenerator) -> Int {
         guard let u = unit() else { return Int.random(in: range, using: &rng) }
         let count = range.upperBound - range.lowerBound + 1
         return range.lowerBound + min(count - 1, Int(u * Double(count)))
@@ -143,6 +163,7 @@ final class LIFSim {
     let locomotor: LocomotorSim?
     var legFeedback: [LegFeedback] = []
     private var cordSourceGroups: [(type: String, side: String, count: Int)] = []
+    private var cordSourceGroupId: [Int] = []   // parallel: resolved LocomotorSim group
     private var cordSourceOf: [Int] = []
     private var cordSourceRates: [Float] = []
     let n: Int
@@ -173,6 +194,11 @@ final class LIFSim {
     private(set) var ascend: [Int] = []    // ascending partners (leg proprioception)
     private(set) var sens: [Int] = []      // sensory partners (air-puff pathway)
     private var ascendPhase: [Float] = []  // per-ascending-neuron gait phase offset
+    // Per-spike classification, resolved once. The counting switch below runs for
+    // every spike of every simulated millisecond, where a String switch plus the
+    // `dnaL.contains(i)` linear scan cost more than the integration it tallies.
+    private enum Tally: UInt8 { case none = 0, loom, dnaLeft, dnaRight, mdn, fwd, groom, escw, gf }
+    private var tally: [UInt8] = []
 
     // inputs (0..1), set each frame by the coordinator
     var loomL: Float = 0
@@ -201,6 +227,10 @@ final class LIFSim {
     // fiber fire before feedforward inhibition arrives.
     private let inhDelayMs = 4
     private var inhQueue: [[Float]]
+    // Which entries of each inhQueue slot are actually non-zero. Scanning all n
+    // floats per slot per millisecond dominated the delayed-inhibition delivery
+    // even though only a handful of targets are ever pending.
+    private var inhTargets: [[Int32]]
     private var qHead = 0
 
     // params
@@ -216,7 +246,7 @@ final class LIFSim {
     private var burstNext = 12_000
 
     let spikeBus: SpikeBus?
-    private var rng = SystemRandomNumberGenerator()
+    private var rng = FastRandom()
 
     // "optogenetic" stimulation from brain-window clicks (any thread)
     private struct Stim { let idx: [Int]; let strength: Float; let durationMs: Int; var untilMs = 0 }
@@ -246,6 +276,7 @@ final class LIFSim {
         v = [Float](repeating: 0, count: n)
         refr = [Float](repeating: 0, count: n)
         inhQueue = Array(repeating: [Float](repeating: 0, count: n), count: 5)
+        inhTargets = Array(repeating: [], count: 5)
 
         for (i, nr) in circuit.neurons.enumerated() {
             switch nr.role {
@@ -266,6 +297,16 @@ final class LIFSim {
             }
         }
         ascendPhase = ascend.map { _ in TestRandom.float(in: 0...(2 * Float.pi)) }
+
+        tally = [UInt8](repeating: Tally.none.rawValue, count: n)
+        for i in loomLeft + loomRight { tally[i] = Tally.loom.rawValue }
+        for i in dnaL { tally[i] = Tally.dnaLeft.rawValue }
+        for i in dnaR { tally[i] = Tally.dnaRight.rawValue }
+        for i in mdn { tally[i] = Tally.mdn.rawValue }
+        for i in fwd { tally[i] = Tally.fwd.rawValue }
+        for i in groom { tally[i] = Tally.groom.rawValue }
+        for i in escw { tally[i] = Tally.escw.rawValue }
+        for i in gf { tally[i] = Tally.gf.rawValue }
 
         // Heterogeneous baseline drive: interneurons get enough to crackle at a
         // few Hz; sensory and command neurons stay quiet unless driven.
@@ -324,6 +365,14 @@ final class LIFSim {
             w[fill[pre]] = weight
             fill[pre] += 1
         }
+
+        // Resolve the homolog group names to indices once. The step loop pushes
+        // these rates every simulated millisecond; building the "type:side" key
+        // there meant a string interpolation and a dictionary hash 8,000 times a
+        // second for eight values that never change identity.
+        cordSourceGroupId = cordSourceGroups.map { g in
+            locomotor?.descendingGroup(g.type, side: g.side) ?? -1
+        }
     }
 
     func consumeGF() -> Bool {
@@ -374,10 +423,12 @@ final class LIFSim {
             }
 
             // deliver delayed inhibition scheduled for this millisecond
-            for j in 0..<n where inhQueue[qHead][j] != 0 {
+            for j32 in inhTargets[qHead] {
+                let j = Int(j32)
                 v[j] = max(-2, v[j] + inhQueue[qHead][j])
                 inhQueue[qHead][j] = 0
             }
+            inhTargets[qHead].removeAll(keepingCapacity: true)
 
             var spiked: [Int] = []
             for i in 0..<n where refr[i] <= 0 && v[i] >= threshold {
@@ -390,7 +441,10 @@ final class LIFSim {
                 for k in rowStart[i]..<rowStart[i + 1] {
                     let j = Int(colIdx[k])
                     if w[k] >= 0 { v[j] = max(-2, v[j] + w[k]) }
-                    else { inhQueue[inhSlot][j] += w[k] }
+                    else {
+                        if inhQueue[inhSlot][j] == 0 { inhTargets[inhSlot].append(Int32(j)) }
+                        inhQueue[inhSlot][j] += w[k]
+                    }
                 }
             }
             qHead = (qHead + 1) % inhQueue.count
@@ -398,14 +452,15 @@ final class LIFSim {
             // group rates (Hz per neuron, EMA)
             var cLoom = 0, cDL = 0, cDR = 0, cM = 0, cF = 0, cG = 0, cW = 0
             for i in spiked {
-                switch roles[i] {
-                case "lc4", "lplc2": cLoom += 1
-                case "dna01", "dna02": if dnaL.contains(i) { cDL += 1 } else { cDR += 1 }
-                case "mdn": cM += 1
-                case "dnp09": cF += 1
-                case "dng11": cG += 1
-                case "escw": cW += 1
-                case "gf": gfLatch = true
+                switch tally[i] {
+                case Tally.loom.rawValue: cLoom += 1
+                case Tally.dnaLeft.rawValue: cDL += 1
+                case Tally.dnaRight.rawValue: cDR += 1
+                case Tally.mdn.rawValue: cM += 1
+                case Tally.fwd.rawValue: cF += 1
+                case Tally.groom.rawValue: cG += 1
+                case Tally.escw.rawValue: cW += 1
+                case Tally.gf.rawValue: gfLatch = true
                 default: break
                 }
             }
@@ -425,8 +480,8 @@ final class LIFSim {
                     let group = cordSourceOf[i]
                     cordSourceRates[group] += 1000 * rateAlpha / Float(cordSourceGroups[group].count)
                 }
-                for (i, group) in cordSourceGroups.enumerated() {
-                    cord.setDescending(group.type, side: group.side, rate: cordSourceRates[i])
+                for (i, group) in cordSourceGroupId.enumerated() where group >= 0 {
+                    cord.setDescending(group: group, rate: cordSourceRates[i])
                 }
                 cord.step(1)
             }

--- a/build.sh
+++ b/build.sh
@@ -2,6 +2,16 @@
 # Build DesktopFly
 set -e
 cd "$(dirname "$0")"
-swiftc -module-cache-path "${TMPDIR:-/tmp}/desktopfly-module-cache" -O -swift-version 5 -o DesktopFly main.swift FlyModel.swift LegDynamics.swift Locomotor.swift LocomotorTests.swift BeetleModel.swift Sim.swift BrainView.swift \
+# -wmo: one optimization unit, so the sim/body call chain inlines across files.
+#   It also happens to build faster than the default primary-file mode here.
+# -enforce-exclusivity=unchecked: the LIF loops touch class-stored arrays a few
+#   million times a second, and the dynamic exclusivity check in front of every
+#   one of those accesses (swift_beginAccess -> thread-local lookup) measured as
+#   the single largest cost in the process. The sim is only ever stepped from the
+#   SceneKit render queue; every cross-thread path goes through Coordinator's
+#   lock or LIFSim.stimulate's, so there is nothing for the check to catch.
+swiftc -module-cache-path "${TMPDIR:-/tmp}/desktopfly-module-cache" -O -wmo \
+    -enforce-exclusivity=unchecked -swift-version 5 -o DesktopFly \
+    main.swift FlyModel.swift LegDynamics.swift Locomotor.swift LocomotorTests.swift BeetleModel.swift Sim.swift BrainView.swift \
     Environment.swift -framework Cocoa -framework SceneKit
 echo "Built ./DesktopFly"

--- a/main.swift
+++ b/main.swift
@@ -972,8 +972,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         scnView.scene = coordinator.scene
         scnView.backgroundColor = .clear
         scnView.allowsCameraControl = false
-        scnView.antialiasingMode = .multisampling4X
-        scnView.preferredFramesPerSecond = 120   // ProMotion; caps at display refresh
+        // A borderless full-screen transparent layer makes the compositor redraw
+        // the desktop behind it at whatever rate this view runs, so the overlay's
+        // frame rate costs more than this process's own render pass. 60 Hz and 2x
+        // MSAA are near-indistinguishable on a body this small; DESKTOPFLY_QUALITY=high
+        // restores 120 Hz / 4x. Neither setting changes the model: SimulationClock
+        // still advances 120 fixed ticks (1000 sim-ms) per second at any frame rate.
+        let highQuality = ProcessInfo.processInfo.environment["DESKTOPFLY_QUALITY"] == "high"
+        scnView.antialiasingMode = highQuality ? .multisampling4X : .multisampling2X
+        scnView.preferredFramesPerSecond = highQuality ? 120 : 60   // caps at display refresh
         if ProcessInfo.processInfo.environment["DESKTOPFLY_FPS"] != nil {
             fputs("display max fps: \(NSScreen.main?.maximumFramesPerSecond ?? 0)\n", stderr)
         }

--- a/windows/src/locomotor.js
+++ b/windows/src/locomotor.js
@@ -21,6 +21,16 @@ export function validateLocomotorCircuit(circuit) {
       neurons.some((nr) => nr.leg === leg && nr.motorChannel === channel)));
 }
 
+// Channel order is shared with Locomotor.swift's motorChannelNames; the step
+// loop indexes it instead of hashing the names on every simulated millisecond.
+const MOTOR_CHANNELS = [
+  'coxa_promotor', 'coxa_anterior_rotator', 'coxa_remotor', 'coxa_posterior_rotator',
+  'trochanter_flexor', 'trochanter_extensor', 'tibia_flexor', 'tibia_extensor',
+];
+const ROLE_OTHER = 0, ROLE_MOTOR = 1, ROLE_SENSORY = 2, ROLE_DESCENDING = 3, ROLE_ASCENDING = 4;
+const SENSE_LOAD = 0, SENSE_HAIR_PLATE = 1, SENSE_EXCURSION = 2;
+const ROLE_CODES = { motor: ROLE_MOTOR, sensory: ROLE_SENSORY, descending: ROLE_DESCENDING, ascending: ROLE_ASCENDING, premotor: ROLE_OTHER };
+
 export class LocomotorSim {
   constructor(circuit, parameters = {}) {
     this.parameters = { synapticGain: 2.4, baseline: 0.022, adaptationKick: 0.01, ...parameters };
@@ -32,13 +42,23 @@ export class LocomotorSim {
       this[field] = new Float64Array(n);
     }
     this.refractory = new Int32Array(n);
-    this.commandGroups = new Map();
-    this.motorGroups = Array.from({ length: 6 }, () => new Map());
+    // The loops below run over ~1,000 neurons a thousand times a second, so
+    // everything they touch is reduced to an integer index here at construction:
+    // a Map hash, a string compare or a neuron-object property load inside them
+    // costs more than the LIF arithmetic it guards. Mirrors Locomotor.swift.
+    this.commandGroupIndex = new Map();
+    this.commandGroupIds = [];
+    this.motorChannelIds = Array.from({ length: 6 * MOTOR_CHANNELS.length }, () => []);
+    this.roleCode = new Uint8Array(n);
     this.sensory = [];
+    this.sensoryLeg = [];
+    this.sensoryKind = [];
     this.commands = Array.from({ length: 6 }, makeLegMotorCommand);
     this.totalSpikes = 0; this.motorSpikes = 0; this.sensorySpikes = 0; this.simMs = 0;
     this.feedback = [];
-    this.silenced = new Set();
+    this.silencedFlag = new Uint8Array(n);
+    this.anySilenced = false;
+    this._silenced = new Set();
     this.synapsesEnabled = true;
     this.feedbackEnabled = true;
     const counts = new Int32Array(n), inputTotal = new Float64Array(n);
@@ -56,26 +76,67 @@ export class LocomotorSim {
       // Keep relative counts and transmitter signs; counts are not conductance.
       this.weights[slot] = this.parameters.synapticGain * weight / Math.max(60, inputTotal[post]);
     }
-    function append(map, key, i) {
-      if (!map.has(key)) map.set(key, []);
-      map.get(key).push(i);
-    }
     circuit.neurons.forEach((nr, i) => {
-      if (nr.role === 'descending') append(this.commandGroups, `${nr.type}:${nr.side}`, i);
-      if (nr.role === 'sensory' && nr.leg != null) this.sensory.push(i);
-      if (nr.role === 'motor' && nr.leg != null && nr.motorChannel) append(this.motorGroups[nr.leg], nr.motorChannel, i);
+      this.roleCode[i] = ROLE_CODES[nr.role] ?? ROLE_OTHER;
+      if (nr.role === 'descending') {
+        const key = `${nr.type}:${nr.side}`;
+        if (!this.commandGroupIndex.has(key)) {
+          this.commandGroupIndex.set(key, this.commandGroupIds.length);
+          this.commandGroupIds.push([]);
+        }
+        this.commandGroupIds[this.commandGroupIndex.get(key)].push(i);
+      }
+      if (nr.role === 'sensory' && nr.leg != null) {
+        this.sensory.push(i);
+        this.sensoryLeg.push(nr.leg);
+        // Same three-way split the step loop used to spell out with string
+        // compares; the pooling rationale is unchanged.
+        this.sensoryKind.push(nr.sensoryKind === 'campaniform' || nr.sensoryKind === 'contact'
+          ? SENSE_LOAD
+          : nr.sensoryKind === 'hair_plate' ? SENSE_HAIR_PLATE : SENSE_EXCURSION);
+      }
+      if (nr.role === 'motor' && nr.leg != null && nr.motorChannel) {
+        const slot = MOTOR_CHANNELS.indexOf(nr.motorChannel);
+        if (slot >= 0) this.motorChannelIds[nr.leg * MOTOR_CHANNELS.length + slot].push(i);
+      }
     });
   }
 
+  // Lesions are diagnostic interventions, used to verify actual causal paths.
+  // The Set stays the API; the hot loop reads the mirrored flags instead, so a
+  // normal run costs one boolean check rather than a hash per neuron per ms.
+  get silenced() { return this._silenced; }
+
+  set silenced(value) {
+    this._silenced = value instanceof Set ? value : new Set(value);
+    this.anySilenced = this._silenced.size > 0;
+    for (let i = 0; i < this.n; i++) this.silencedFlag[i] = this._silenced.has(i) ? 1 : 0;
+  }
+
   setDescending(type, side, rate) {
-    for (const i of this.commandGroups.get(`${type}:${side}`) || []) {
-      this.drive[i] = Math.min(0.35, Math.max(0, rate) * 0.004);
-    }
+    const group = this.descendingGroup(type, side);
+    if (group >= 0) this.setDescendingGroup(group, rate);
+  }
+
+  // Index form of the above, for the caller that resolves its groups once.
+  descendingGroup(type, side) {
+    const group = this.commandGroupIndex.get(`${type}:${side}`);
+    return group === undefined ? -1 : group;
+  }
+
+  setDescendingGroup(group, rate) {
+    const value = Math.min(0.35, Math.max(0, rate) * 0.004);
+    for (const i of this.commandGroupIds[group]) this.drive[i] = value;
   }
 
   indices(role, leg = null) {
-    return this.circuit.neurons.map((nr, i) => i).filter((i) =>
-      this.circuit.neurons[i].role === role && (leg === null || this.circuit.neurons[i].leg === leg));
+    const code = ROLE_CODES[role];
+    if (code === undefined) return [];
+    const out = [];
+    for (let i = 0; i < this.n; i++) {
+      if (this.roleCode[i] === code && (leg === null || this.circuit.neurons[i].leg === leg)) out.push(i);
+    }
+    return out;
   }
 
   meanRate(role, leg = null) {
@@ -89,15 +150,16 @@ export class LocomotorSim {
       this.simMs++;
       for (const i of this.sensory) this.sensoryDrive[i] = 0;
       if (this.feedbackEnabled && this.feedback.length === 6) {
-        for (const i of this.sensory) {
-          const nr = this.circuit.neurons[i], f = this.feedback[nr.leg];
-          const value = nr.sensoryKind === 'campaniform' || nr.sensoryKind === 'contact'
+        for (let k = 0; k < this.sensory.length; k++) {
+          const f = this.feedback[this.sensoryLeg[k]];
+          const kind = this.sensoryKind[k];
+          const value = kind === SENSE_LOAD
             ? (f.contact ? Math.min(1, f.load * 6) : 0)
-            : nr.sensoryKind === 'hair_plate'
+            : kind === SENSE_HAIR_PLATE
               ? Math.min(1, Math.abs(f.hipAngle) / LegDynamics.hipLimit + Math.abs(f.elevationVelocity) / 20)
               : Math.min(1, Math.abs(f.kneeVelocity) / 20 + Math.abs(f.hipVelocity) / 16
               + Math.abs(f.kneeAngle - LegDynamics.restKnee) * 0.35);
-          this.sensoryDrive[i] = value * 0.10;
+          this.sensoryDrive[this.sensory[k]] = value * 0.10;
         }
       }
       for (let i = 0; i < this.n; i++) {
@@ -108,7 +170,7 @@ export class LocomotorSim {
       for (let i = 0; i < this.n; i++) {
         this.rates[i] *= 0.9048374;
         this.adaptation[i] *= 0.9950125;
-        if (this.silenced.has(i)) { this.voltage[i] = 0; this.rates[i] = 0; continue; }
+        if (this.anySilenced && this.silencedFlag[i]) { this.voltage[i] = 0; this.rates[i] = 0; continue; }
         if (this.refractory[i] > 0) { this.refractory[i]--; continue; }
         this.voltage[i] = Math.max(-1, this.voltage[i] * 0.9512294 + this.excitatory[i] + this.inhibitory[i]
           + this.parameters.baseline + this.drive[i] + this.sensoryDrive[i] - this.adaptation[i]);
@@ -117,8 +179,8 @@ export class LocomotorSim {
           this.adaptation[i] += this.parameters.adaptationKick;
           this.rates[i] += 95.16258;
           this.totalSpikes++;
-          if (this.circuit.neurons[i].role === 'motor') this.motorSpikes++;
-          if (this.circuit.neurons[i].role === 'sensory') this.sensorySpikes++;
+          if (this.roleCode[i] === ROLE_MOTOR) this.motorSpikes++;
+          else if (this.roleCode[i] === ROLE_SENSORY) this.sensorySpikes++;
           if (this.synapsesEnabled) {
             for (let e = this.rowStart[i]; e < this.rowStart[i + 1]; e++) {
               if (this.weights[e] >= 0) this.nextExcitatory[this.targets[e]] += this.weights[e];
@@ -129,15 +191,19 @@ export class LocomotorSim {
       }
     }
     for (let leg = 0; leg < 6; leg++) {
-      const activity = (channel) => {
-        const ids = this.motorGroups[leg].get(channel) || [];
-        const rate = ids.reduce((sum, i) => sum + this.rates[i], 0) / Math.max(1, ids.length);
+      const base = leg * MOTOR_CHANNELS.length;
+      const activity = (slot) => {
+        const ids = this.motorChannelIds[base + slot];
+        if (!ids.length) return 0;
+        const rate = ids.reduce((sum, i) => sum + this.rates[i], 0) / ids.length;
         return rate / (rate + 50);
       };
-      this.commands[leg] = { protract: Math.max(activity('coxa_promotor'), activity('coxa_anterior_rotator')),
-        retract: Math.max(activity('coxa_remotor'), activity('coxa_posterior_rotator')),
-        lift: activity('trochanter_flexor'), depress: activity('trochanter_extensor'),
-        flex: activity('tibia_flexor'), extend: activity('tibia_extensor') };
+      // Slots follow MOTOR_CHANNELS: promotor, anterior rotator, remotor,
+      // posterior rotator, trochanter flexor/extensor, tibia flexor/extensor.
+      this.commands[leg] = { protract: Math.max(activity(0), activity(1)),
+        retract: Math.max(activity(2), activity(3)),
+        lift: activity(4), depress: activity(5),
+        flex: activity(6), extend: activity(7) };
     }
   }
 }

--- a/windows/src/sim.js
+++ b/windows/src/sim.js
@@ -80,6 +80,10 @@ export class LIFSim {
     this.v = new Float32Array(n);
     this.refr = new Float32Array(n);
     this.inhQueue = Array.from({ length: 5 }, () => new Float32Array(n));
+    // Which entries of each slot are actually non-zero. Scanning all n floats per
+    // slot per millisecond dominated delayed-inhibition delivery even though only
+    // a handful of targets are ever pending. Mirrors Sim.swift's inhTargets.
+    this.inhTargets = Array.from({ length: 5 }, () => []);
     this.qHead = 0;
 
     // groups
@@ -144,6 +148,11 @@ export class LIFSim {
       this.cordSourceOf[i] = group;
     });
     this.cordSourceRates = new Float32Array(this.cordSourceGroups.length);
+    // Resolve the homolog group names to indices once. The step loop pushes these
+    // rates every simulated millisecond; building the "type:side" key there meant
+    // a string build and a Map hash 8,000 times a second for eight fixed values.
+    this.cordSourceGroupId = this.cordSourceGroups.map((group) =>
+      (this.locomotor ? this.locomotor.descendingGroup(group.type, group.side) : -1));
 
     // hot-loop lookups (Swift used string switches and dnaL.contains)
     // 1 loom, 2 dnaL, 3 dnaR, 4 mdn, 5 fwd, 6 groom, 7 escw, 8 gf
@@ -299,9 +308,12 @@ export class LIFSim {
 
       // deliver delayed inhibition scheduled for this millisecond
       const q = this.inhQueue[this.qHead];
-      for (let j = 0; j < n; j++) {
+      const qTargets = this.inhTargets[this.qHead];
+      for (let t = 0; t < qTargets.length; t++) {
+        const j = qTargets[t];
         if (q[j] !== 0) { v[j] = Math.max(-2, v[j] + q[j]); q[j] = 0; }
       }
+      qTargets.length = 0;
 
       let nSpiked = 0;
       for (let i = 0; i < n; i++) {
@@ -312,13 +324,14 @@ export class LIFSim {
       }
       this.totalSpikes += nSpiked;
       const inh = this.inhQueue[(this.qHead + this.inhDelayMs) % this.inhQueue.length];
+      const inhTargets = this.inhTargets[(this.qHead + this.inhDelayMs) % this.inhQueue.length];
       for (let s = 0; s < nSpiked; s++) {
         const i = spiked[s];
         const end = this.rowStart[i + 1];
         for (let k = this.rowStart[i]; k < end; k++) {
           const j = this.colIdx[k], wk = this.w[k];
           if (wk >= 0) v[j] = Math.max(-2, v[j] + wk);
-          else inh[j] += wk;
+          else { if (inh[j] === 0) inhTargets.push(j); inh[j] += wk; }
         }
       }
       this.qHead = (this.qHead + 1) % this.inhQueue.length;
@@ -355,8 +368,10 @@ export class LIFSim {
           const group = this.cordSourceOf[spiked[s]];
           if (group >= 0) this.cordSourceRates[group] += 1000 * a / this.cordSourceGroups[group].count;
         }
-        this.cordSourceGroups.forEach((group, i) =>
-          this.locomotor.setDescending(group.type, group.side, this.cordSourceRates[i]));
+        this.cordSourceGroups.forEach((group, i) => {
+          const id = this.cordSourceGroupId[i];
+          if (id >= 0) this.locomotor.setDescendingGroup(id, this.cordSourceRates[i]);
+        });
         this.locomotor.step(1);
       }
 


### PR DESCRIPTION
Sampling a running instance showed the process spending most of its time in
places that were not the neural arithmetic. This branch fixes those. **The
model is untouched** — all three suites, on both platforms, produce
byte-identical output to before.

## Result

Real CPU, same machine, same conditions, 8 instantaneous samples each:

| | samples | mean |
|---|---|---|
| before | 14.3 20.4 18.6 26.9 14.1 19.9 17.5 24.6 | **19.5%** |
| after | 9.6 7.9 11.4 6.7 4.6 14.4 9.7 10.3 | **9.3%** |

`--locomotortest` as a synthetic benchmark: **9.48s → 1.5–3.0s**.

## Where the time was going

`sample` on a live process, 5 s at 1 ms. Of the process's on-CPU samples, ~65%
sat under `Coordinator.renderer` → `LIFSim.step`, which is expected — both sims
step at 1 kHz over ~1,700 neurons, so ~6.6M neuron updates a second.

What was *not* expected is the largest group of leaf samples:

```
swift::runtime::SwiftTLSContext::get()                    184
swift_beginAccess                                         112
swift::runtime::AccessSet::insert(...)                     98
swift_endAccess                                            66
DYLD-STUB$$swift_begin/endAccess                           23
```

That is Swift's dynamic exclusivity enforcement. The LIF state lives in
class-stored arrays and the loops touch them millions of times a second, so
every `voltage[i] = …` paid a thread-local lookup. `-O` does not remove those
checks.

## Commit 1 — build flags and overlay render cost

`-enforce-exclusivity=unchecked`. The sim is only ever stepped from the SceneKit
render queue; both cross-thread entry points (`Coordinator.enqueue`,
`LIFSim.stimulate`) already take a lock, so the check had nothing to catch here.

```
--locomotortest, 5 runs each:
  -O               9.53  7.78  9.34  9.34  9.44 s
  + -wmo           no measurable change (but ~5 s faster to build)
  + unchecked      1.84  3.35  1.87  3.24  1.92 s
  + -Ounchecked    no further gain, so bounds checks stay on
```

Also `-wmo`, and the overlay defaults to 60 Hz / 2x MSAA with 120 / 4x behind
`DESKTOPFLY_QUALITY=high`. The overlay is a borderless full-screen transparent
layer, so its frame rate also drives desktop recompositing. This does not touch
the model: `SimulationClock` still advances 120 fixed ticks (1000 sim-ms) per
second at any display rate — that is what the accumulator is for.

## Commit 2 — per-millisecond lookups

The profile also showed `CFStringHash`, `_stringCompareWithSmolCheck`,
`__RawDictionaryStorage.find` and `Hasher.combine` inside the step loops, and
`activity #1 (_:) in LocomotorSim.step` never inlining. All resolved to integer
indices at init:

**`Locomotor.swift`**
- `roleCode[]` replaces `circuit.neurons[i].role == "motor"` on every spike —
  that compare also copied a struct with six retained `String` fields
- `motorChannelIds[leg*8+slot]` replaces 48 string-keyed dictionary lookups per
  millisecond in the leg readout, plus its `?? []` allocation
- `sensoryLeg[]` / `sensoryKind[]` replace the per-sensory-neuron string compares
- `silencedFlag[]` / `anySilenced` replace a `Set<Int>` hash per neuron per ms
  (~1.05M/s) for a set that is empty outside lesion tests. The `Set` stays the
  public API via `didSet`.
- `commandGroupIndex` resolves `"type:side"` once; `setDescending(group:)` is
  the index form

**`Sim.swift`**
- `tally[]` replaces the per-spike `String` switch and the `dnaL.contains()`
  linear scan. The JS port already did this; the Swift side had drifted behind.
- `inhTargets[]` records which delayed-inhibition entries are non-zero, so
  delivery walks a handful of targets instead of scanning all 668 floats per ms
- `cordSourceGroupId` resolves the homolog group names once instead of building
  eight `"type:side"` strings every simulated millisecond
- `FastRandom` (splitmix64) replaces `SystemRandomNumberGenerator` for membrane
  noise — ~670k draws/s were going through an AES-CTR CSPRNG for a jitter term.
  Seeded test runs never reach it, so `TestRandom`'s stream and its agreement
  with `windows/test/random.js` are untouched.

**`BrainView.swift`**
- Fade the spike-flash pool by hand and resolve the round-robin before touching
  SceneKit. A frame drains hundreds of sampled spikes into 48 nodes, so the old
  path built and immediately cancelled thousands of `SCNAction` sequences a
  second to draw the same final state.

Mirrored to `windows/src/{sim,locomotor}.js` per the porting rule in CLAUDE.md.

## Verification

- `--simtest`, `--behaviortest`, `--locomotortest`: byte-identical to before,
  except the one `elapsed` timing field
- `npm test` in `windows/`: byte-identical
- `--brainshot` and `--snapshot --top --walking` render correctly

## One thing worth flagging

`-enforce-exclusivity=unchecked` is load-bearing, not a nice-to-have. Measured
separately: the commit-2 source fixes *without* the flag only move
`--locomotortest` 9.48 → ~8.4 s. The cost is spread across the bare
`voltage[i]` / `rates[i]` element accesses, and removing it properly would mean
rewriting ~15 arrays in both sims around `UnsafeMutablePointer` — which would
drop bounds checking too. The flag is the milder of the two options: it drops
only the overlapping-access check and leaves bounds checks on. Reasoning is in
`build.sh`'s comment and the commit message, so it is not a silent trade.

Happy to split this into two PRs, or to drop the 60 Hz / 2x MSAA default if you
would rather keep the overlay at 120 / 4x — that part is one line and
independent of the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
